### PR TITLE
DOC: disable footer links to internal docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
 html_theme = 'sphinx_audeering_theme'
 html_theme_options = {
     'display_version': True,
+    'footer_links': False,
     'logo_only': False,
     'wide_pages': ['example-wide-pages'],
 }


### PR DESCRIPTION
Disable the links in the footer section that point to our internal documentation.