### PR TITLE
TST: add installation of doc requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |


### PR DESCRIPTION
The tests were working before, even I removed or forgot the doc requirements to install. This is fixed by this pull request.