### PR TITLE
Support multiline changelog in automatic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,15 @@ jobs:
     - name: Read CHANGELOG
       id: changelog
       run: |
-        echo "::set-output name=body::$(git diff -U0 HEAD^ HEAD | grep '^[+]' | grep -Ev '^(--- a/|\+\+\+ b/)' | sed 's/\+//')"
+        # Get the last enrty to CHANGELOG
+        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+]' | grep -Ev '^(--- a/|\+\+\+ b/)' | sed 's/\+//')
+        # Support for multiline, see
+        # https://github.com/actions/create-release/pull/11#issuecomment-640071918
+        CHANGELOG="${CHANGELOG//'%'/'%25'}"
+        CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+        CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+        echo "Got changelog: $CHANGELOG"
+        echo "::set-output name=body::$CHANGELOG"
     - name: Create release on Github
       id: create_release
       uses: actions/create-release@v1


### PR DESCRIPTION
Automatic extraction of the CHANGELOG is working, but only a single line was added to https://github.com/audeering/sphinx-audeering-theme/releases/tag/v1.0.3

This applies the fix described at https://github.com/actions/create-release/pull/11#issuecomment-640071918 to support multiline entries.