### PR TITLE
Add missing script block in layout.html

### DIFF
--- a/sphinx_audeering_theme/layout.html
+++ b/sphinx_audeering_theme/layout.html
@@ -199,6 +199,12 @@
   </div>
   {% include "versions.html" %}
 
+
+  {# JAVASCRIPTS #}
+  {%- block scripts %}
+  <!--[if lt IE 9]>
+    <script src="{{ pathto('_static/js/html5shiv.min.js', 1) }}"></script>
+  <![endif]-->
   {% if not embedded %}
 
     {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
@@ -233,6 +239,7 @@
           SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
       });
   </script>
+  {%- endblock %}
 
   {%- block footer %} {% endblock %}
 


### PR DESCRIPTION
Closes #23 

It seems to be that they introduced a new `scripts` block in the RTD theme. This is [referenced in search.html](https://github.com/readthedocs/sphinx_rtd_theme/blob/e2b60d7e7b2b6feb8a45b224950608ad11668a7e/sphinx_rtd_theme/search.html#L13) in order to add the JS file. As we hadn't the block defined in our `layout.html` file it was not inserting it.

I added now the missing block to `layout.html` and for me the search is working. In order to test the search locally, you have to allow the browser to reference local files, e.g.

```bash
$ chromium-browser --allow-file-access-from-files
```
Otherwise you will get javascript errors.

For me the output now looks like this:

![image](https://user-images.githubusercontent.com/173624/100084985-c22bb000-2e4b-11eb-85f9-a4833b4335e9.png)
