### PR TITLE
Pin docutils<0.17

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ packages = find:
 install_requires =
     sphinx
     sphinx_rtd_theme ==0.4.3
+    docutils <0.17  # https://github.com/sphinx-doc/sphinx/issues/9088
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Sphinx and the RTD theme are slightly broken for newer versions of `docutils`. They have decided to pin `docutils`, see https://github.com/sphinx-doc/sphinx/issues/9088
but this is not integrated into the RTD theme version we are depending on.
As a workaround I will add the pinning to our theme as well.