### PR TITLE
Fix bottom margin for docstring tables

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -98,6 +98,10 @@ body {
     margin-bottom: 12px;
     margin-top: 12px;
 }
+/* Fix row margins for tables in docstrings */
+.rst-content dl table td p {
+    margin-bottom: 0px !important;
+}
 /* Fix border lines in table headers */
 .wy-table-responsive thead th {
     border: solid 1px #e1e4e5;


### PR DESCRIPTION
Changes tables in docstrings from

![image](https://user-images.githubusercontent.com/173624/127114485-4449b1ae-0861-4675-80f9-985c249e9a4d.png)

to

![image](https://user-images.githubusercontent.com/173624/127114557-54f74249-9ea2-4f3d-8be2-5c4eccce5a5d.png)
