### PR TITLE
DOC: ignore sphinx-doc.org in linkcheck

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,7 +53,7 @@ It is also possible to automatically check if all links are still valid::
 
    python -m sphinx docs/ build/sphinx/html -b linkcheck
 
-.. _Sphinx: http://sphinx-doc.org/
+.. _Sphinx: https://sphinx-doc.org/
 
 
 Running the Tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,9 @@ pygments_style = None
 extensions = [
     'sphinx.ext.autodoc',
 ]
+linkcheck_ignore = [
+    'https://sphinx-doc.org',
+]
 
 # HTML --------------------------------------------------------------------
 html_theme = 'sphinx_audeering_theme'


### PR DESCRIPTION
Changes link to sphinx-doc.org to https and ignores it in linkcheck.