### PR TITLE
Fix bottom margin for table headers

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -99,7 +99,7 @@ body {
     margin-top: 12px;
 }
 /* Fix row margins for tables in docstrings */
-.rst-content dl table td p {
+.rst-content dl p {
     margin-bottom: 0px !important;
 }
 /* Fix border lines in table headers */


### PR DESCRIPTION
For tables inside docstrings this changes the appearance from

![image](https://user-images.githubusercontent.com/173624/137858333-0f1ce43a-1bc8-4c24-a960-d7f94ea47ba9.png)

to

![image](https://user-images.githubusercontent.com/173624/137858373-c3bd09c7-a1be-4cf6-a48d-64fde8e059d9.png)
