### PR TITLE
Style admonition colors

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -124,7 +124,7 @@ a:hover {
     background: var(--light-grey);
 }
 .rst-content .important {
-    background: var(--light-grey);
+    background: var(--red-opaque);
 }
 .rst-content .note {
     background: var(--light-grey);
@@ -154,7 +154,7 @@ a:hover {
     background: var(--dark-grey);
 }
 .rst-content .important .admonition-title {
-    background: var(--dark-grey);
+    background: var(--red);
 }
 .rst-content .note .admonition-title {
     background: var(--dark-grey);


### PR DESCRIPTION
Closes #38

This uses audEERING colors for the admonitions, and changes the default of the color note to grey instead of red:

![image](https://user-images.githubusercontent.com/173624/138652154-684ceb40-20c4-48dc-86f0-306c9ffe09f7.png)
