### PR TITLE
Fix bullet removal for parameter lists

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -210,7 +210,7 @@ dl.property em {
     font-style: normal;
 }
 /* Remove bullet points from parameter lists */
-.rst-content .section dl.class ul li {
+.rst-content .section dl.field-list.simple ul li {
     list-style: none;
     margin-left: 0;
 }


### PR DESCRIPTION
In some documentations (`audplot`) the current CSS configuration was not removing the bullet points for the parameter list.
This is now fixed:

![image](https://user-images.githubusercontent.com/173624/139222314-06e2eb8d-47f1-4757-bac4-49f904e8c25b.png)
