### PR TITLE
Indent after first line in parameter lists

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -212,7 +212,10 @@ dl.property em {
 /* Remove bullet points from parameter lists */
 .rst-content .section dl.field-list.simple ul li {
     list-style: none;
-    margin-left: 0;
+    margin-left: 24px;
+    /* Don't indent first line of text, see */
+    /* https://gitlab.audeering.com/project/altavista-cc/tests/-/issues/19 */
+    text-indent: -24px;
 }
 /* Make heading of example section look like other sections */
 .rst-content dl.class p.rubric,


### PR DESCRIPTION
Closes #44.

I think it will be easier to read if we indent after the first line in parameter lists, e.g. 

![image](https://user-images.githubusercontent.com/173624/139644432-878f5dad-415e-495f-8df2-4b938f2c057d.png)
