### PR TITLE
Change link for infrastructure pages

### DIFF
--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -16,7 +16,7 @@
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
       {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
-      {% set infra = '<a href="http://devops.pp.audeering.com">Infrastructure</a>' %}
+      {% set infra = '<a href="http://it.pp.audeering.com">Infrastructure</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}

--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -16,7 +16,7 @@
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
       {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
-      {% set infra = '<a href="http://it.pp.audeering.com">Infrastructure</a>' %}
+      {% set infra = '<a href="http://it.pp.audeering.com/infrastructure/">Infrastructure</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}


### PR DESCRIPTION
As discussed recently it makes more sense to point the infrastructure pages link to the actual infrastructure pages and not devops pages. We can link to the devops pages from there, so we only have one entrypoint to the infrastructure.