### PR TITLE
Use black font for class/function name

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -91,18 +91,6 @@ a:hover {
     /* Color of TOC captions */
     color: var(--dark-grey);
 }
-.rst-content dl:not(.docutils) dt {
-    color: var(--red);
-    border-left: solid 3px var(--red);
-    border-top: none;
-    background: var(--light-grey);
-}
-.rst-content dl:not(.docutils) dl dt {
-    color: var(--black);
-    border-left: solid 3px var(--grey);
-    border-top: none;
-    background: var(--light-grey);
-}
 
 /***** ADMONITIONS (NOTES) ***********************************************/
 .rst-content .admonition {
@@ -204,13 +192,34 @@ content .viewcode-back {
     border: none;
     background-color: transparent;
 }
-/* Force arguments to be in normal font in header */
+/* Function/Class definition names */
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) code.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) code.descclassname {
+    color: var(--black);
+}
 dl.class em,
 dl.function em,
 dl.method em,
 dl.property em {
     font-style: normal;
 }
+.rst-content dl:not(.docutils) dt {
+    color: var(--red);
+    border-left: solid 3px var(--red);
+    border-top: none;
+    background: var(--light-grey);
+}
+.rst-content dl:not(.docutils) dl dt {
+    color: var(--black);
+    border-left: solid 3px var(--grey);
+    border-top: none;
+    background: var(--light-grey);
+}
+
 /* Remove bullet points from parameter lists */
 .rst-content .section dl.field-list.simple ul li {
     list-style: none;

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -193,13 +193,10 @@ content .viewcode-back {
     background-color: transparent;
 }
 /* Function/Class definition names */
-.rst-content dl:not(.docutils) tt.descname,
-.rst-content dl:not(.docutils) tt.descclassname,
-.rst-content dl:not(.docutils) tt.descname,
-.rst-content dl:not(.docutils) code.descname,
-.rst-content dl:not(.docutils) tt.descclassname,
-.rst-content dl:not(.docutils) code.descclassname {
+.rst-content dl:not(.docutils) .descname,
+.rst-content dl:not(.docutils) .descclassname {
     color: var(--black);
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
 }
 dl.class em,
 dl.function em,


### PR DESCRIPTION
Closes #46 

Use the code default font and black color for function/class names in API definitions.

![image](https://user-images.githubusercontent.com/173624/146535862-cc5b34ce-27a5-4be1-a4ad-892cd5e1ef6e.png)
