### PR TITLE
Allow italic font in docstrings

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -198,10 +198,10 @@ content .viewcode-back {
     color: var(--black);
     font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
 }
-dl.class em,
-dl.function em,
-dl.method em,
-dl.property em {
+dl.class dt em,
+dl.function dt em,
+dl.method dt em,
+dl.property dt em {
     font-style: normal;
 }
 .rst-content dl:not(.docutils) dt {


### PR DESCRIPTION
We force function arguments in API documentations to be non-italic, e.g.

![image](https://user-images.githubusercontent.com/173624/163331327-51c92470-6788-4185-8f78-af8399b4ae38.png)

This had the unwanted side effect, that also italic text in the body of the docstring was forced to be non-italic.
This is fixed by this pull request, e.g.

![image](https://user-images.githubusercontent.com/173624/163331490-af0f461b-3b18-42be-b89a-1cc904c68166.png)
