### PR TITLE
Mark extension as safe for parallel read/write

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
         python -m pytest
     - name: Test building documentation
       run: |
-        python -m sphinx docs/ docs/_build/ -b html -W
+        python -m sphinx docs/ docs/_build/ -b html -W -j 2
         python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/sphinx_audeering_theme/__init__.py
+++ b/sphinx_audeering_theme/__init__.py
@@ -81,6 +81,8 @@ def setup(app):
     app.add_html_theme('sphinx_audeering_theme',
                        os.path.abspath(os.path.dirname(__file__)))
 
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}
+
 
 def _run(shell_command):
     """Return the output of a shell command provided as string."""


### PR DESCRIPTION
Sphinx can speed up building documentation by using multiple processes. In order to do so extensions must indicate that they are safe to be executed in parallel. The original `sphinx_rtd_theme` is safe, so our theme should be safe as well.