### PR TITLE
Fix nested ul bottom margin

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -436,3 +436,12 @@ footer li {
 footer p {
   margin-bottom: 10px;
 }
+
+/***** MISCELLANEOUS *****************************************************/
+/* Fixes https://github.com/readthedocs/sphinx_rtd_theme/issues/996 */
+.wy-plain-list-disc li ul,
+.rst-content .section ul li ul,
+.rst-content .toctree-wrapper ul li ul,
+article ul li ul {
+  margin-bottom: 12px;
+}


### PR DESCRIPTION
This adds a CSS fix for https://github.com/readthedocs/sphinx_rtd_theme/issues/996 which we are encountering several times in our docs.

Before:
![image](https://user-images.githubusercontent.com/64791786/167126760-edc9d406-235e-4f32-93cf-cbe0abad5ca6.png)

After:
![image](https://user-images.githubusercontent.com/64791786/167126691-d78e5750-3ee1-49e4-b085-3b5816f1804d.png)

