### PR TITLE
Fix margin and floating of class properties

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -38,6 +38,12 @@ body {
     /* Decrease distance between paragraphs */
     margin-bottom: 10px !important;
 }
+/* Fix display of class properties in API */
+/* See: https://github.com/audeering/sphinx-audeering-theme/issues/57 */
+.rst-content dl:not(.docutils) .property {
+    display: contents;
+    padding-right: 0px;
+}
 
 /***** LINKS *************************************************************/
 a {


### PR DESCRIPTION
Closes #57 

This adds two changes to API pages:
* normalize the margin after class property entries
* avoid right floating of class property entries

The examples presented in #57 now look like this:

![image](https://user-images.githubusercontent.com/173624/168006017-cbdd00f0-5059-4571-a52e-1c9d363c8718.png)

and

![image](https://user-images.githubusercontent.com/173624/168006131-0fc7f6e0-1747-4fcd-ab05-ecd5c46dca94.png)
