### PR TITLE
Fix property definition

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -41,8 +41,8 @@ body {
 /* Fix display of class properties in API */
 /* See: https://github.com/audeering/sphinx-audeering-theme/issues/57 */
 .rst-content dl:not(.docutils) .property {
-    display: contents;
-    padding-right: 0px;
+    display: revert;
+    padding-right: 4px;
 }
 
 /***** LINKS *************************************************************/


### PR DESCRIPTION
Follow up on https://github.com/audeering/sphinx-audeering-theme/pull/58.

There was an issue with the margin between `class` and the name of the class in the property field.