### PR TITLE
Change Infrastructure link to http://devops.pp.audeering.com

### DIFF
--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -16,15 +16,13 @@
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
       {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
-      {% set infra = '<a href="http://devops.pp.audeering.com/it-infrastructure/">Infrastructure</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}
-      {% trans data=data, doc=doc, infra=infra, python=python, tools=tools %}
+      {% trans data=data, doc=doc, python=python, tools=tools %}
         <ul>
           <li>{{ data }}</li>
           <li>{{ doc }}</li>
-          <li>{{ infra }}</li>
           <li>{{ models }}</li>
           <li>{{ python }}</li>
           <li>{{ tools }}</li>

--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -16,7 +16,7 @@
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
       {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
-      {% set infra = '<a href="http://devops.pp.audeering.com/it-infrastructure/">Infrastructure</a>' %}
+      {% set infra = '<a href="http://devops.pp.audeering.com/">Infrastructure</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}

--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -16,13 +16,15 @@
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
       {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
+      {% set infra = '<a href="http://devops.pp.audeering.com/it-infrastructure/">Infrastructure</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}
-      {% trans data=data, doc=doc, python=python, tools=tools %}
+      {% trans data=data, doc=doc, infra=infra, python=python, tools=tools %}
         <ul>
           <li>{{ data }}</li>
           <li>{{ doc }}</li>
+          <li>{{ infra }}</li>
           <li>{{ models }}</li>
           <li>{{ python }}</li>
           <li>{{ tools }}</li>


### PR DESCRIPTION
To increase trust in the links inside the footer, I propose to remove the "Infrastructure" link until there is a page we can link to.