### PR TITLE
Add Research link to footer

### DIFF
--- a/sphinx_audeering_theme/footer.html
+++ b/sphinx_audeering_theme/footer.html
@@ -15,10 +15,11 @@
   <div>
     {%- if theme_footer_links %}
       {% set data = '<a href="http://data.pp.audeering.com">Data</a>' %}
-      {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Documentation</a>' %}
-      {% set infra = '<a href="http://devops.pp.audeering.com/">Infrastructure</a>' %}
+      {% set doc = '<a href="http://devops.pp.audeering.com/sphinx/">Docs</a>' %}
+      {% set infra = '<a href="http://devops.pp.audeering.com/">Infra</a>' %}
       {% set models = '<a href="http://models.pp.audeering.com">Models</a>' %}
       {% set python = '<a href="http://devops.pp.audeering.com/python/">Python</a>' %}
+      {% set python = '<a href="http://research.pp.audeering.com">Research</a>' %}
       {% set tools = '<a href="http://tools.pp.audeering.com">Tools</a>' %}
       {% trans data=data, doc=doc, infra=infra, python=python, tools=tools %}
         <ul>


### PR DESCRIPTION
Changes to footer

* Add `Research` link
* Rename `Documentation` link to `Docs`
* Rename `Infrstructure` link to `Infra`

![image](https://user-images.githubusercontent.com/173624/205054353-195313e0-838d-498b-ae33-e84138f05504.png)
