### PR TITLE
TST: ignore internal link for link check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
 ]
 linkcheck_ignore = [
     'https://sphinx-doc.org',
+    'http://devops.pp.audeering.com',
 ]
 
 # HTML --------------------------------------------------------------------


### PR DESCRIPTION
Excludes http://devops.pp.audeering.com from the linkcheck.