### PR TITLE
CI: fix automatic generated release name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        name: Release ${{ github.ref }}
+        tag_name: ${{ steps.get_version.outputs.version }}
+        name: Release ${{ steps.get_version.outputs.version }}
         body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
At the moment the following release names are generated:

![image](https://user-images.githubusercontent.com/173624/205071443-10efcc8d-2c85-4879-b550-3052b4204c0f.png)

Based on https://github.com/equinor/cargo-tracker-reference/blob/840ce0f0b31ad657d5c0732c10348fed048db408/.github/workflows/tag-release.yml#L43-L44 this tries to remove the `refs/tags/` part from the version number.