### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
+
+    - name: Install pre-commit hooks
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files
+
     - name: Test with pytest
       run: |
         python -m pytest
+
     - name: Test building documentation
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W -j 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,6 +33,39 @@ even if you pull new changes from the Github repository.
 .. _Github: https://github.com/audeering/sphinx-audeering-theme/
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,13 @@ install_requires =
 setup_requires =
     setuptools_scm
 
-[tool:pytest]
-addopts =
-    --flake8
+[flake8]
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
+pre-commit
 pytest
 pytest-flake8


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.