### PR TITLE
Require sphinx<7.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    sphinx >=5.1.0
+    sphinx >=5.1.0, <7.0.0  # https://github.com/readthedocs/readthedocs.org/issues/10279
     docutils <0.17  # https://github.com/sphinx-doc/sphinx/issues/9088
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
The version of the RTD theme is no longer compatible due to the removal of the `style` key in `sphinx` 7.0.0, compare https://github.com/sphinx-doc/sphinx/pull/11381/files.

As I don't know how to modify the theme to fix this we require `sphinx<7.0.0` instead.