### PR TITLE
DOC: update title to sphinx-audeering-theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ======================
-Sphinx audEERING theme
+sphinx-audeering-theme
 ======================
 
 |tests| |docs| |python-versions| |license| 


### PR DESCRIPTION
To be in line with other packages, this now uses lower case letters and incudes the `-` in the name:

![image](https://github.com/audeering/sphinx-audeering-theme/assets/173624/bd42bf9f-5cb8-4231-b641-051f1691b150)
