### PR TITLE
Add CSS entries for audbcards preview table

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -343,11 +343,6 @@ dl.property dt em {
 }
 
 /***** TABLE PREVIEW in AUDBCARDS ****************************************/
-.rst-content table.docutils:not(.field-list) tr.clickable:hover td,
-.rst-content table.docutils:not(.field-list) tr.clickable:hover th {
-    /* Change color of table row for mouse hover */
-    background-color: #e3e3e3;
-}
 .rst-content table.docutils:not(.field-list) tr.clickable table.preview tr:nth-child(2n-1) td {
     /* Don't style odd and even rows differently in preview table */
     background-color: inherit;

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -306,7 +306,6 @@ dl.property dt em {
 }
 .wy-table-responsive thead th {
     /* Fix border lines in table headers */
-    border: solid 1px var(--grey);
     border-bottom: solid 2px var(--grey);
 }
 .wy-table-responsive tbody tr th.stub {

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -362,6 +362,15 @@ table.preview th p {
     /* Adjust font size of header in preview table to table content */
     font-size: 13px;
 }
+.rst-content table.docutils:not(.field-list) tr.clickable td.expanded-row-content {
+    /* Remove double border on left side of cell holding preview table */
+    border-left: none;
+}
+.rst-content table.docutils:not(.field-list) tr.clickable td table.preview td {
+    /* Remove complete border in preview table cells */
+    border-left: none;
+    border-bottom: none;
+}
 
 /***** FIGURE AND TABLE CAPTIONS *****************************************/
 .wy-table caption, .rst-content table.docutils caption,

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -343,6 +343,27 @@ dl.property dt em {
     margin-bottom: 0 !important;
 }
 
+/***** TABLE PREVIEW in AUDBCARDS ****************************************/
+.rst-content table.docutils:not(.field-list) tr.clickable:hover td,
+.rst-content table.docutils:not(.field-list) tr.clickable:hover th {
+    /* Change color of table row for mouse hover */
+    background-color: #e3e3e3;
+}
+.rst-content table.docutils:not(.field-list) tr.clickable table.preview tr:nth-child(2n-1) td {
+    /* Don't style odd and even rows differently in preview table */
+    background-color: inherit;
+}
+.rst-content table.docutils:not(.field-list) tr.clickable table.preview td,
+.rst-content table.docutils:not(.field-list) tr.clickable table.preview th {
+    /* Reduce padding to vertically center cell content in preview table,
+     * and reduce height of table cells */
+    padding-bottom: 4px;
+}
+table.preview th p {
+    /* Adjust font size of header in preview table to table content */
+    font-size: 13px;
+}
+
 /***** FIGURE AND TABLE CAPTIONS *****************************************/
 .wy-table caption, .rst-content table.docutils caption,
 .rst-content table.field-list caption, .rst-content div.figure p.caption {

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -371,6 +371,11 @@ table.preview th p {
     border-left: none;
     border-bottom: none;
 }
+table.clickable tr.clicked td:not(.expanded-row-content):not(:first-child) {
+    /* Remove left border on clicked row when preview is shown,
+     * without changing position of the text */
+    border-left: 1px solid transparent;
+}
 
 /***** FIGURE AND TABLE CAPTIONS *****************************************/
 .wy-table caption, .rst-content table.docutils caption,


### PR DESCRIPTION
Add additional styling for the table preview tables introduced in https://github.com/audeering/audbcards/pull/97.

* Adjust font-size of preview table header
* Center font in preview table cell, and reduce height of preview table cell
* Don't use alternating colors for odd and even rows in preview table (was anyway only working for white rows of the tables table)
* Remove vertical lines in table headers
* Remove border on clicked row to make better connection with preview table

The screenshot from https://github.com/audeering/audbcards/pull/97 now looks like

![image](https://github.com/user-attachments/assets/d311f0fc-de0f-45df-866b-9209eeff17bb)