### PR TITLE
Require sphinx>=6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ classifiers = [
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
-    'sphinx >=5.1.0, <7.0.0',  # https://github.com/readthedocs/readthedocs.org/issues/10279
-    'docutils <0.17',  # https://github.com/sphinx-doc/sphinx/issues/9088
+    'sphinx >=6.0.0, <7.0.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -46,7 +46,21 @@ body {
 }
 /* Fix bottom margin of nested bullet points */
 /* https://github.com/audeering/sphinx-audeering-theme/pull/56 */
-.rst-content .section ol p, .rst-content .section ul p {
+.rst-content section ol p, .rst-content section ul p {
+    margin-bottom: 0;
+}
+/* Fix bullet point lists */
+/* https://github.com/audeering/sphinx-audeering-theme/issues/72 */
+.rst-content section ul {
+    list-style: disc;
+    line-height: 24px;
+    margin-bottom: 24px;
+}
+.rst-content section ul li {
+    list-style: disc;
+    margin-left: 24px;
+}
+.rst-content section ul li p:last-child {
     margin-bottom: 0;
 }
 
@@ -229,7 +243,7 @@ dl.property dt em {
 }
 
 /* Remove bullet points from parameter lists */
-.rst-content .section dl.field-list.simple ul li {
+.rst-content section dl.field-list.simple ul li {
     list-style: none;
     margin-left: 24px;
     /* Don't indent first line of text, see */


### PR DESCRIPTION
Closes #72 

Add support for `sphinx>=6.0.0` and newer docutils versions.

## Summary by Sourcery

Allow the theme to work with newer Sphinx and docutils versions while fixing list rendering in documentation pages.

Bug Fixes:
- Correct bullet list styling and spacing for unordered lists and nested paragraphs in documentation content.

Enhancements:
- Update CSS selectors from the deprecated .section structure to the HTML5 section elements used by newer Sphinx versions.

Build:
- Relax and update the Sphinx dependency to require versions >=6.0.0 and <7.0.0, removing the explicit docutils pin.