### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'sphinx >=6.0.0, <7.0.0',
 ]


### PR DESCRIPTION
Remove support for deprecated Python 3.8

## Summary by Sourcery

Drop support for Python 3.8 across configuration and packaging metadata.

Enhancements:
- Update project metadata to advertise support for Python 3.9+ only, setting minimum required Python version to 3.9.

Build:
- Update CI test matrix to stop running tests on Python 3.8.