### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,12 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'sphinx >=6.0.0, <7.0.0',
 ]


### PR DESCRIPTION
Remove support for deprecated Python 3.9

## Summary by Sourcery

Drop Python 3.9 support across packaging metadata and CI configuration.

Build:
- Update packaging metadata to require Python 3.10+ and remove the Python 3.9 classifier.

CI:
- Remove Python 3.9 from the GitHub Actions test matrix.