### PR TITLE
Add support for sphinx<9.0.0

### DIFF
--- a/docs/example-api.rst
+++ b/docs/example-api.rst
@@ -46,10 +46,6 @@ Theme
 .. autoclass:: sphinx.theming.Theme
     :members:
 
-extract_zip
------------
-
-.. autofunction:: sphinx.theming.extract_zip
 
 .. _sphinx.ext.autodoc:
     http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'sphinx >=6.0.0, <7.0.0',
+    'sphinx >=6.0.0, <9.0.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Add support for `sphinx` versions up to 9.0.0.

## Summary by Sourcery

Build:
- Broaden the Sphinx version constraint in pyproject.toml from <7.0.0 to <9.0.0 to support newer Sphinx releases.