### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.4.0 (2026-01-02)
+--------------------------
+
+* Added: support for Python 3.13
+* Changed: depend on ``sphinx>=6.0.0``
+* Removed: support for Python 3.8
+* Removed: support for Python 3.9
+
+
 Version 1.3.0 (2024-07-25)
 --------------------------
 
@@ -15,6 +24,7 @@ Version 1.3.0 (2024-07-25)
 * Added: support for Python 3.11
 * Changed: require ``sphinx<7.0.0``
 * Removed: support for Python 3.7
+* Fixed: CSS styling with ``docutils>=0.17``
 
 
 Version 1.2.1 (2022-12-01)


### PR DESCRIPTION
<img width="323" height="165" alt="image" src="https://github.com/user-attachments/assets/ed700c28-8d90-4e52-960d-0c5ff16f4db6" />

## Summary by Sourcery

Documentation:
- Adjust the CHANGELOG entry to reflect the 1.4.0 release notes.