### PR TITLE
Fix extra space in table header

### DIFF
--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -319,18 +319,13 @@ dl.property dt em {
 }
 /* Allow for line breaks in Tables.
  * See: https://stackoverflow.com/a/40650120 */
-.wy-table-responsive table td {
-    white-space: normal;
-}
-table td {
+.wy-table-responsive table td,
+.rst-content table td {
     white-space: normal;
 }
 /* Fix vertical placement in tables */
-.wy-table-responsive table td ol.arabic {
-    margin-bottom: 12px;
-    margin-top: 12px;
-}
-table td ol.arabic {
+.wy-table-responsive table td ol.arabic,
+.rst-content table td ol.arabic {
     margin-bottom: 12px;
     margin-top: 12px;
 }
@@ -341,17 +336,13 @@ table td ol.arabic {
     margin-bottom: 0 !important;
 }
 /* Fix table headers margin */
-.wy-table-responsive thead th p {
-    margin-bottom: 0 !important;
-}
-table thead th p {
+.wy-table-responsive thead th p,
+.rst-content table thead th p {
     margin-bottom: 0 !important;
 }
 /* Fix table row headers margin */
-.wy-table-responsive tbody tr th p {
-    margin-bottom: 0 !important;
-}
-table tbody tr th p {
+.wy-table-responsive tbody tr th p,
+.rst-content table tbody tr th p {
     margin-bottom: 0 !important;
 }
 

--- a/sphinx_audeering_theme/static/css/audeering.css
+++ b/sphinx_audeering_theme/static/css/audeering.css
@@ -322,8 +322,15 @@ dl.property dt em {
 .wy-table-responsive table td {
     white-space: normal;
 }
+table td {
+    white-space: normal;
+}
 /* Fix vertical placement in tables */
 .wy-table-responsive table td ol.arabic {
+    margin-bottom: 12px;
+    margin-top: 12px;
+}
+table td ol.arabic {
     margin-bottom: 12px;
     margin-top: 12px;
 }
@@ -337,10 +344,17 @@ dl.property dt em {
 .wy-table-responsive thead th p {
     margin-bottom: 0 !important;
 }
+table thead th p {
+    margin-bottom: 0 !important;
+}
 /* Fix table row headers margin */
 .wy-table-responsive tbody tr th p {
     margin-bottom: 0 !important;
 }
+table tbody tr th p {
+    margin-bottom: 0 !important;
+}
+
 
 /***** TABLE PREVIEW in AUDBCARDS ****************************************/
 .rst-content table.docutils:not(.field-list) tr.clickable table.preview tr:nth-child(2n-1) td {


### PR DESCRIPTION
Closes #99 

This ensures our CSS fixes for table header to also cover general tables, as we do not always get `.wy-table-responsive` with newer versions of `sphinx`.

Result with fix

<img width="273" height="93" alt="image" src="https://github.com/user-attachments/assets/5d9f1b13-d6e6-4ab0-a322-711bf8a73233" />
