### PR TITLE
Fix custom logo support

### DIFF
--- a/sphinx_audeering_theme/layout.html
+++ b/sphinx_audeering_theme/layout.html
@@ -98,11 +98,11 @@
           {% block sidebartitle %}
 
           <a href="{{ pathto(master_doc) }}">
-          {% if logo %}
+          {% if logo_url %}
             {# Not strictly valid HTML, but it's the only way to display/scale
                it properly, without weird scripting or heaps of work
             #}
-            <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="Logo"/>
+            <img src="{{ logo_url }}" class="logo" alt="Logo"/>
           {% else %}
             <img src="{{ pathto('_static/images/audeering.png', 1) }}" class="logo" alt="audEERING"/>
           {% endif %}


### PR DESCRIPTION
# Description

It seems like `logo` is not set, even if consumers of the theme set `html_logo` properly. The correct way in subsequent Sphinx version seems to be to use `logo_url` instead.
See https://github.com/readthedocs/sphinx_rtd_theme/blob/795de79c8b311592f5863a25307d85924bf52164/sphinx_rtd_theme/layout.html#L116